### PR TITLE
Docs: Add user-friendly contribution page instead of linking to repo file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: Build Check
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  workflow_call:
+
+# ensure that the workflow is only triggered once per PR, subsequent pushes to the PR will cancel
+# and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-check:
+    name: stable / build-check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build check
+        run: pnpm build

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "sharp": "^0.33.5"
   },
   "devDependencies": {
+    "@types/mdx": "^2.0.13",
     "@types/node": "18.11.10",
     "tailwindcss": "^3.4.15",
     "typescript": "^4.9.5"

--- a/pages/_meta.tsx
+++ b/pages/_meta.tsx
@@ -1,4 +1,4 @@
-import { Home, BookText, PocketKnife, CookingPot } from 'lucide-react'
+import { Home, BookText, PocketKnife, CookingPot, SquareArrowOutUpRight, ExternalLink } from 'lucide-react'
 
 const iconStyle = {
   width: '1rem',
@@ -26,13 +26,13 @@ const meta = {
     "type": "page"
   },
   "apiReference": {
-    "title": "API Reference ↗",
+    "title": <>API Reference <ExternalLink style={iconStyle} /></>,
     "type": "page",
     "href": "https://docs.rs/rig-core",
     "newWindow": true
   },
   "contact": {
-    "title": "Contact ↗",
+    "title": <>Contact <ExternalLink style={iconStyle} /></>,
     "type": "page",
     "href": "https://playgrounds.network",
     "newWindow": true

--- a/pages/about.mdx
+++ b/pages/about.mdx
@@ -1,3 +1,0 @@
-# About
-
-This is the about page! This page is shown on the navbar.

--- a/pages/docs/1_why_rig.mdx
+++ b/pages/docs/1_why_rig.mdx
@@ -1,5 +1,5 @@
 ---
-title: ❓Why Rig?
+title: ❓ Why Rig?
 description: This section contains the compelling reasons to use Rig for your next LLM project.
 ---
 

--- a/pages/docs/7_how-to-contribute.mdx
+++ b/pages/docs/7_how-to-contribute.mdx
@@ -1,21 +1,38 @@
+---
+title: How to Contribute?
+description: This section contains the different areas where your help is most needed.
+---
+
+import { Callout } from 'nextra/components'
+import { Hammer, Lightbulb, Book, MessageCircleQuestion } from 'lucide-react'
+
+
+export const section_icon = { display: 'inline', size: '1rem', marginBottom: '0.25rem' }    
+
 <div className="section-title">How to Contribute?</div>
 
 Rig is an open-source project and we welcome contributions from the community. 
 Whether you're a developer, designer, or writer, there are many ways to contribute to the project. 
 The section below outlines the different areas where your help is most needed.
 
-## 🛠️ Development
+<Callout type="info" emoji="👋">
+**Prior to starting the work on a new feature or change**, make sure to search for existing issues and pull requests on the [GitHub repository](https://github.com/0xPlaygrounds/rig/issues) to discuss your ideas or changes. Open an issue if there is none.
+</Callout>
+
+## <><Hammer style={section_icon}/> Development </>
 ### Model Provider Integrations
 Rig aims to support a wide range of language models from different providers.
 If your favorite model provide is not supported, consider adding support for it in Rig and making a pull request for it!
 
 Important information about model provider integrations:
-- Each model provider integration is contained in its own module under [`rig-core/src/providers`](https://github.com/0xPlaygrounds/rig/tree/main/rig-core/src/providers).
+- Each **model provider integration** is contained in its own module under [`rig-core/src/providers`](https://github.com/0xPlaygrounds/rig/tree/main/rig-core/src/providers).
 - If the provider has an OpenAI compatible API, there is no need to write a new provider module since Rig already supports OpenAI. 
 Instead, you can simply add documentation indicating how you can use the existing [`openai`](https://github.com/0xPlaygrounds/rig/blob/main/rig-core/src/providers/openai.rs) integration to use the new provider.
-- ❗Model provider integrations should not require new dependencies that are not already included in the project. 
-If you need to add a new dependency, please open an issue for the integration to discuss it first.
 - Make sure to follow the repository's [contribution guidelines](https://github.com/0xPlaygrounds/rig/blob/main/CONTRIBUTING.md).
+
+<Callout type="warning" emoji="⚠️">
+Model provider integrations should not require new dependencies that are not already included in the project. 
+</Callout>
 
 ### Vector Store Integrations
 Rig aims to support a wide range of vector stores for storing and retrieving embeddings. 
@@ -33,7 +50,7 @@ If you find a bug in Rig, please open an issue for it on the [repository](https:
 
 Make sure to follow the repository's [contribution guidelines](https://github.com/0xPlaygrounds/rig/blob/main/CONTRIBUTING.md).
 
-## 📝 Documentation
+## <><Book style={section_icon}/> Documentation </>
 ### Guides and Tutorials
 If you have experience with Rig and would like to share your knowledge with others, consider writing a guide or tutorial for the project!
 
@@ -42,7 +59,7 @@ If you would like your tutorial to be featured on this website, please open a pu
 ### Other Documentation Improvements
 If you find a typo or mistake in the documentation, or any section that could use improvement, please open an issue to report it or a pull request to fix it on the [docs repository](https://github.com/0xPlaygrounds/rig-docs).
 
-## 🧠 Ideas and Feedback
+## <><Lightbulb style={section_icon}/> Ideas and Feedback </>
 If you have an idea for a new Rig feature or feedback on existing features, please let us know by opening an issue on the [GitHub repository](https://github.com/0xPlaygrounds/rig/issues)!
 
 Make sure to checkout the existing issues first to make sure your idea is not already planned or in progress 😉.

--- a/pages/docs/_meta.tsx
+++ b/pages/docs/_meta.tsx
@@ -1,4 +1,4 @@
-import { Blocks, Lightbulb, CircleHelp, DraftingCompass, Landmark, Puzzle, Rocket, Unplug, MessageCircleQuestion } from "lucide-react";
+import { Blocks, Lightbulb, CircleHelp, DraftingCompass, Landmark, Puzzle, Rocket, Unplug, MessageCircleQuestion, HeartHandshake } from "lucide-react";
 
 const iconStyle = {
   width: '1rem',
@@ -13,7 +13,8 @@ const meta = {
   "3_architecture": {title: <><Landmark style={iconStyle} /> &nbsp; Architecture</>},
   "4_concepts": {title: <><Puzzle style={iconStyle} /> &nbsp; Concepts</>},
   "5_integrations": {title: <><Unplug style={iconStyle} /> &nbsp; Integrations</>},
-  "6_extensions": {title: <><Blocks style={iconStyle} /> &nbsp; Extensions</>}
+  "6_extensions": {title: <><Blocks style={iconStyle} /> &nbsp; Extensions</>},
+  "7_how-to-contribute": {title: <><HeartHandshake style={iconStyle} /> &nbsp; Contribute to Rig</>}
 }
 
 export default meta;

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: This section contains the high-level documentation for Rig.
 ---
 
-import { Blocks, CircleHelp, Landmark, Plug } from 'lucide-react'
+import { Blocks, CircleHelp, Landmark, Plug, HeartHandshake } from 'lucide-react'
 import { Cards } from 'nextra/components'
 
 # Docs
@@ -56,5 +56,15 @@ This section contains the high-level documentation for Rig.
         </div>
     }
     />
+    <Cards.Card
+    title="How to Contribute?"
+    icon={<HeartHandshake />}
+    href="/docs/7_how-to-contribute"
+    children={    <div style={{ fontSize: '0.9em', color: '#666', whiteSpace: 'normal', wordWrap: 'break-word' }}>
+        How to contribute to Rig.
+        </div>
+    }
+    />
 </Cards>
+
 

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: This section contains the high-level documentation for Rig.
 ---
 
-import { CircleHelp, Landmark, Plug } from 'lucide-react'
+import { Blocks, CircleHelp, Landmark, Plug } from 'lucide-react'
 import { Cards } from 'nextra/components'
 
 # Docs

--- a/pages/examples/0_model_providers/anthropic.mdx
+++ b/pages/examples/0_model_providers/anthropic.mdx
@@ -4,3 +4,5 @@ description: This section describes the Anthropic API (Claude) integration.
 ---
 
 # Anthropic API (Claude) Integration
+
+Coming soon™️...

--- a/pages/examples/0_model_providers/openai.mdx
+++ b/pages/examples/0_model_providers/openai.mdx
@@ -4,3 +4,7 @@ description: This section describes the OpenAI API integration.
 ---
 
 # OpenAI API Integration
+
+Coming soon™️...
+
+

--- a/pages/examples/_meta.tsx
+++ b/pages/examples/_meta.tsx
@@ -1,5 +1,6 @@
 export default {
     "index": "Get Started",
+    "0_model_providers": "Model Providers",
     "1_rag": "RAG",
     "2_basics": "Basic",
     "3_advanced": "Advanced"

--- a/pages/how-to-contribute.mdx
+++ b/pages/how-to-contribute.mdx
@@ -1,0 +1,48 @@
+<div className="section-title">How to Contribute?</div>
+
+Rig is an open-source project and we welcome contributions from the community. 
+Whether you're a developer, designer, or writer, there are many ways to contribute to the project. 
+The section below outlines the different areas where your help is most needed.
+
+## 🛠️ Development
+### Model Provider Integrations
+Rig aims to support a wide range of language models from different providers.
+If your favorite model provide is not supported, consider adding support for it in Rig and making a pull request for it!
+
+Important information about model provider integrations:
+- Each model provider integration is contained in its own module under [`rig-core/src/providers`](https://github.com/0xPlaygrounds/rig/tree/main/rig-core/src/providers).
+- If the provider has an OpenAI compatible API, there is no need to write a new provider module since Rig already supports OpenAI. 
+Instead, you can simply add documentation indicating how you can use the existing [`openai`](https://github.com/0xPlaygrounds/rig/blob/main/rig-core/src/providers/openai.rs) integration to use the new provider.
+- ❗Model provider integrations should not require new dependencies that are not already included in the project. 
+If you need to add a new dependency, please open an issue for the integration to discuss it first.
+- Make sure to follow the repository's [contribution guidelines](https://github.com/0xPlaygrounds/rig/blob/main/CONTRIBUTING.md).
+
+### Vector Store Integrations
+Rig aims to support a wide range of vector stores for storing and retrieving embeddings. 
+If your favorite vector store is not supported, consider adding support for it in Rig and making a pull request for it!
+
+Important information about vector store integrations:
+- Each vector store integration is contained in its own crate located in the root of the repository. 
+The naming convention for vector store crates is `rig-<store_name>` (e.g. [`rig-mongodb`](https://github.com/0xPlaygrounds/rig/tree/main/rig-mongodb)). 
+This is because vector store integrations often require many additional dependencies that are not needed otherwise.
+- Consider adding an integration test for the integration! You can base yourself off of the existing vector store integration tests like this one for [Qdrant](https://github.com/0xPlaygrounds/rig/blob/main/rig-qdrant/tests/integration_tests.rs).
+- Make sure to follow the repository's [contribution guidelines](https://github.com/0xPlaygrounds/rig/blob/main/CONTRIBUTING.md).
+
+### Bug Fixes
+If you find a bug in Rig, please open an issue for it on the [repository](https://github.com/0xPlaygrounds/rig/issues) and consider making a pull request to fix it.
+
+Make sure to follow the repository's [contribution guidelines](https://github.com/0xPlaygrounds/rig/blob/main/CONTRIBUTING.md).
+
+## 📝 Documentation
+### Guides and Tutorials
+If you have experience with Rig and would like to share your knowledge with others, consider writing a guide or tutorial for the project!
+
+If you would like your tutorial to be featured on this website, please open a pull request on the [docs repository](https://github.com/0xPlaygrounds/rig-docs).
+
+### Other Documentation Improvements
+If you find a typo or mistake in the documentation, or any section that could use improvement, please open an issue to report it or a pull request to fix it on the [docs repository](https://github.com/0xPlaygrounds/rig-docs).
+
+## 🧠 Ideas and Feedback
+If you have an idea for a new Rig feature or feedback on existing features, please let us know by opening an issue on the [GitHub repository](https://github.com/0xPlaygrounds/rig/issues)!
+
+Make sure to checkout the existing issues first to make sure your idea is not already planned or in progress 😉.

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -60,7 +60,7 @@ Note: Rig does not support WASM (yet), but we're working on it!
   />
   <Cards.Card
     title="🤝 How to Contribute?"
-    href="https://github.com/0xPlaygrounds/rig/blob/main/CONTRIBUTING.md"
+    href="/how-to-contribute"
     children={    <div style={{ fontSize: '0.9em', color: '#666', whiteSpace: 'normal', wordWrap: 'break-word' }}>
       Learn how to contribute to the Rig project.
     </div>

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -60,7 +60,7 @@ Note: Rig does not support WASM (yet), but we're working on it!
   />
   <Cards.Card
     title="🤝 How to Contribute?"
-    href="/how-to-contribute"
+    href="/docs/7_how-to-contribute"
     children={    <div style={{ fontSize: '0.9em', color: '#666', whiteSpace: 'normal', wordWrap: 'break-word' }}>
       Learn how to contribute to the Rig project.
     </div>

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -1,5 +1,5 @@
 import { Cards } from 'nextra/components'
-import { WalletCards, Rocket } from 'lucide-react'
+import { Blocks, WalletCards, Rocket, BrainCircuit, Lightbulb } from 'lucide-react'
 
 # Get Started with `cargo add rig-core{:bash}`
 Rig is a Rust library for building portable, modular, and lightweight Fullstack AI Agents. You can find API documentation on [docs.rs](https://docs.rs/rig-core).
@@ -59,7 +59,7 @@ Note: Rig does not support WASM (yet), but we're working on it!
   }
   />
   <Cards.Card
-    title="🤝 Contributing"
+    title="🤝 How to Contribute?"
     href="https://github.com/0xPlaygrounds/rig/blob/main/CONTRIBUTING.md"
     children={    <div style={{ fontSize: '0.9em', color: '#666', whiteSpace: 'normal', wordWrap: 'break-word' }}>
       Learn how to contribute to the Rig project.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
         specifier: ^0.33.5
         version: 0.33.5
     devDependencies:
+      '@types/mdx':
+        specifier: ^2.0.13
+        version: 2.0.13
       '@types/node':
         specifier: 18.11.10
         version: 18.11.10


### PR DESCRIPTION
- Add a dedicated "How to contribute?" page that contains more high level information useful for potential contributors such as which areas are in most need of work!
- Add a basic CI build check
- Fix missing imports