### PR TITLE
ci: remove github pages workflows, add lint/issue link actions

### DIFF
--- a/.github/workflows/issues_autolink.yml
+++ b/.github/workflows/issues_autolink.yml
@@ -1,0 +1,16 @@
+name: 'Issue Autolink'
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  issue-links:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: tkt-actions/add-issue-links@v1.8.1
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}'
+          branch-prefix: 'i'
+          resolve: 'true'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,44 @@
+name: Code Check
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+
+concurrency:
+  group: ${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: ⬣ ESLint, ʦ TypeScript, 💅 Prettier, and 🃏 Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v4
+
+      - name: 🤌 Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: 📥 Download deps
+        run: pnpm install --frozen-lockfile
+
+      - name: 🔬 Lint
+        run: pnpm run lint:strict
+
+      - name: 🔎 Type check
+        run: pnpm run typecheck
+
+      - name: 💅 Prettier check
+        run: pnpm run format:check
+
+      - name: 🃏 Run jest
+        run: pnpm run test


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to automate issue linking and code linting. The workflows are designed to streamline the development process by automatically linking issues to pull requests and ensuring code quality through linting, type checking, formatting, and testing.

New GitHub Actions workflows:

* [`.github/workflows/issues_autolink.yml`](diffhunk://#diff-3e849ddcb46f1706b5fc5a0b362b79c96fed944780902d48e51c5736c6288d4eR1-R16): Added a workflow to automatically link issues to pull requests when they are opened. This workflow uses the `tkt-actions/add-issue-links` action and runs on `ubuntu-latest`.

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R1-R44): Added a comprehensive code check workflow that runs on pushes to the `main` branch and on pull requests. This workflow includes steps for checking out the repository, setting up `pnpm` and `node`, installing dependencies, linting the code, performing type checks, running Prettier, and executing tests with Jest.